### PR TITLE
Lauracowen k8sguidetitle

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@
 :imagesdir: /img/guide/{projectid}
 :source-highlighter: prettify
 :page-seo-title: Deploying microservices to Red Hat OpenShift 4 using Kubernetes Operators
-:page-seo-description: A getting started tutorial with examples on how to deploy cloud-native Java applications and microservices to Red Hat OpenShift cluster using Kubernetes Operators like the Open Liberty Operator.
+:page-seo-description: A getting started tutorial with examples on how to deploy cloud-native Java applications and microservices to Red Hat OpenShift cluster by using Kubernetes Operators like the Open Liberty Operator.
 :guide-author: Open Liberty
 = Deploying microservices to OpenShift 4 using Kubernetes Operators
 

--- a/README.adoc
+++ b/README.adoc
@@ -10,26 +10,26 @@
 :page-layout: guide-multipane
 :page-duration: 30 minutes
 :page-releasedate: 2020-10-30
-:page-description: Explore how to deploy microservices to Red Hat OpenShift 4 by using Kubernetes Operators like the Open Liberty Operator.
+:page-description: Explore how to deploy microservices to Red Hat OpenShift 4 using Kubernetes Operators like the Open Liberty Operator.
 :page-tags: ['Kubernetes', 'Docker', 'Cloud'] 
 :page-permalink: /guides/{projectid}
 :page-related-guides: ['cloud-openshift', 'okd']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/prod
 :imagesdir: /img/guide/{projectid}
 :source-highlighter: prettify
-:page-seo-title: Deploying microservices to Red Hat OpenShift 4 by using Kubernetes Operators
-:page-seo-description: A getting started tutorial with examples on how to deploy cloud-native Java applications and microservices to Red Hat OpenShift cluster by using Kubernetes Operators like the Open Liberty Operator.
+:page-seo-title: Deploying microservices to Red Hat OpenShift 4 using Kubernetes Operators
+:page-seo-description: A getting started tutorial with examples on how to deploy cloud-native Java applications and microservices to Red Hat OpenShift cluster using Kubernetes Operators like the Open Liberty Operator.
 :guide-author: Open Liberty
-= Deploying microservices to OpenShift 4 by using Kubernetes Operators
+= Deploying microservices to OpenShift 4 using Kubernetes Operators
 
 [.hidden]
 NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website^].
 
-Explore how to deploy microservices to Red Hat OpenShift 4 by using Kubernetes Operators.
+Explore how to deploy microservices to Red Hat OpenShift 4 using Kubernetes Operators.
 
 == What you'll learn 
 
-You will learn how to deploy a cloud-native application with 2 microservices to Red Hat OpenShift 4 by using Kubernetes Operators like the Open Liberty Operator. 
+You will learn how to deploy a cloud-native application with 2 microservices to Red Hat OpenShift 4 using Kubernetes Operators like the Open Liberty Operator. 
 You will install two operators into an OpenShift cluster and use them to deploy and scale sample microservices. 
 
 https://www.openshift.com/[OpenShift^] is a Kubernetes-based platform with added functions. It streamlines the DevOps


### PR DESCRIPTION
Removed "by" from "by using" in the title and first sentence. It's fine elsewhere in the body of the guide where it tends to be in the context of longer sentences and is useful for disambiguation. But in the title it reads oddly/clunkily and it's not how it would be said normally.